### PR TITLE
fix(reconcile): forProvider.Name check & domainNames.toLower

### DIFF
--- a/pkg/client/compare_types.go
+++ b/pkg/client/compare_types.go
@@ -1,5 +1,7 @@
 package client
 
+import "strings"
+
 // IsEqualString determinetes if StringValue's of two pointers are equal.
 func IsEqualString(s1 *string, s2 *string) bool {
 	return StringValue(s1) == StringValue(s2)
@@ -22,11 +24,13 @@ func IsEqualStringArrayContent(a1 []string, a2 []string) bool {
 
 	map2 := make(map[string]struct{}, len(a2))
 	for _, a2v := range a2 {
-		map2[a2v] = struct{}{}
+		a2vl := strings.ToLower(a2v)
+		map2[a2vl] = struct{}{}
 	}
 
 	for _, a1v := range a1 {
-		if _, exists := map2[a1v]; !exists {
+		a1vl := strings.ToLower(a1v)
+		if _, exists := map2[a1vl]; !exists {
 			return false
 		}
 	}

--- a/pkg/controller/applicationsegment/controller.go
+++ b/pkg/controller/applicationsegment/controller.go
@@ -372,5 +372,9 @@ func isUpToDate(cr *v1alpha1.ApplicationSegmentParameters, gobj *application_con
 		return false
 	}
 
+	if !zpaclient.IsEqualString(zpaclient.StringToPtr(cr.Name), zpaclient.StringToPtr(obj.Name)) {
+		return false
+	}
+
 	return true
 }

--- a/pkg/controller/segmentgroup/controller.go
+++ b/pkg/controller/segmentgroup/controller.go
@@ -262,5 +262,9 @@ func isUpToDate(cr *v1alpha1.SegmentGroupParameters, gobj *segment_group_control
 		return false
 	}
 
+	if !zpaclient.IsEqualString(cr.Name, obj.Name) {
+		return false
+	}
+
 	return true
 }

--- a/pkg/controller/server/controller.go
+++ b/pkg/controller/server/controller.go
@@ -288,5 +288,9 @@ func isUpToDate(cr *v1alpha1.ServerParameters, gobj *app_server_controller.GetAp
 		return false
 	}
 
+	if !zpaclient.IsEqualString(cr.Name, obj.Name) {
+		return false
+	}
+
 	return true
 }

--- a/pkg/controller/servergroup/controller.go
+++ b/pkg/controller/servergroup/controller.go
@@ -309,5 +309,9 @@ func isUpToDate(cr *v1alpha1.ServerGroupParameters, gobj *server_group_controlle
 		return false
 	}
 
+	if !zpaclient.IsEqualString(zpaclient.StringToPtr(cr.Name), zpaclient.StringToPtr(obj.Name)) {
+		return false
+	}
+
 	return true
 }


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- check forProvider.Names if we need an update
- set domainNames string array content to lower to check content 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

```
Name:         example-application
Namespace:    
Labels:       <none>
Annotations:  crossplane.io/external-create-pending: 2022-02-01T12:05:05+01:00
              crossplane.io/external-create-succeeded: 2022-02-01T12:05:05+01:00
              crossplane.io/external-name: 216196723335233675
API Version:  zpa.crossplane.io/v1alpha1
Kind:         ApplicationSegment
Metadata:
  Creation Timestamp:  2022-02-01T11:05:04Z
  Finalizers:
    finalizer.managedresource.crossplane.io
  Generation:  7
    Manager:         provider
    Operation:       Update
    Time:            2022-02-01T11:05:09Z
  Resource Version:  1551192
  UID:               38cdd5fa-740d-499b-a232-f5dc7d6d6a76
Spec:
  Deletion Policy:  Delete
  For Provider:
    Bypass Type:   NEVER
    Config Space:  DEFAULT
    Domain Names:
      kibana.test.crossplane.io
      alertmanager.test.crossplane.io
      prometheus.test.crossplane.io
      grafana.test.crossplane.io
      AAAAA.example.com
    Double Encrypt:          false
    Enabled:                 true
    Health Check Type:       DEFAULT
    Health Reporting:        ON_ACCESS
    Icmp Access Type:        NONE
    Ip Anchored:             false
    Is Cname Enabled:        true
    Name:                    App-Seg_CROSSPLANE_SOP-test-update
    Passive Health Enabled:  true
    Segment Group ID:        216196723335233674
    Segment Group ID Ref:
      Name:  example-segment
    Tcp Port Ranges:
      443
      443
  Provider Config Ref:
    Name:  zpa-provider
Status:
  At Provider:
    Creation Time:  1643713505
    Id:             216196723335233675
    Modified By:    216196723335233575
    Modified Time:  1643717871
  Conditions:
    Last Transition Time:  2022-02-01T11:05:09Z
    Reason:                Available
    Status:                True
    Type:                  Ready
    Last Transition Time:  2022-02-01T11:05:05Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
Events:
  Type    Reason                   Age    From                                          Message
  ----    ------                   ----   ----                                          -------
  Normal  UpdatedExternalResource  7m14s  managed/applicationsegment.zpa.crossplane.io  Successfully requested update of external resource

```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
